### PR TITLE
ゲーム一覧のページネーションを1ページ10件表示に変更

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -24,3 +24,48 @@
 .time_text{
   font-size: 12px;
 }
+
+// ページネーション
+.pagination-modern {
+  .page-link {
+    border: none;
+    border-radius: 8px !important;
+    min-width: 38px;
+    height: 38px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 500;
+    color: #495057;
+    background-color: #f8f9fa;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: #0d6efd;
+      color: #fff;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px rgba(13, 110, 253, 0.3);
+    }
+  }
+
+  .page-item.active .page-link {
+    background-color: #0d6efd;
+    color: #fff;
+    box-shadow: 0 4px 8px rgba(13, 110, 253, 0.35);
+  }
+
+  .page-item.disabled .page-link {
+    background-color: transparent;
+    color: #adb5bd;
+  }
+
+  .gap-link {
+    background-color: transparent;
+    &:hover {
+      background-color: transparent;
+      color: #adb5bd;
+      transform: none;
+      box-shadow: none;
+    }
+  }
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,6 @@
 class GamesController < ApplicationController
     def index
-        @games = params[:name].present? ? Hardware.find(params[:name]).games.order(release_date: :desc).page(params[:page]).per(5) : Game.order(release_date: :desc).page(params[:page]).per(5)
+        @games = params[:name].present? ? Hardware.find(params[:name]).games.order(release_date: :desc).page(params[:page]).per(10) : Game.order(release_date: :desc).page(params[:page]).per(10)
         #@hardwares = Hardware.where(id: GameHardware.where(game_id: Game.where(id: @games)))
         #@genres = Genre.where(id: GameGenre.where(game_id: Game.where(id: @games)))
     end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -43,4 +43,7 @@
     </div>
   <% end %>
 </div>
+<div class="d-flex justify-content-center my-4">
+  <%= paginate @games %>
+</div>
 </body>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,5 @@
+<li class="page-item">
+  <%= link_to url, remote: remote, rel: "first", class: "page-link", aria: { label: "最初のページ" } do %>
+    <i class="bi bi-chevron-double-left"></i>
+  <% end %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item disabled" aria-disabled="true">
+  <span class="page-link gap-link">…</span>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,5 @@
+<li class="page-item">
+  <%= link_to url, remote: remote, rel: "last", class: "page-link", aria: { label: "最後のページ" } do %>
+    <i class="bi bi-chevron-double-right"></i>
+  <% end %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,5 @@
+<li class="page-item">
+  <%= link_to url, remote: remote, rel: "next", class: "page-link", aria: { label: "次のページ" } do %>
+    <i class="bi bi-chevron-right"></i>
+  <% end %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? -%>
+  <li class="page-item active" aria-current="page">
+    <span class="page-link"><%= page.number %></span>
+  </li>
+<% else -%>
+  <li class="page-item">
+    <%= link_to page.number, url, remote: remote, rel: page.rel, class: "page-link" %>
+  </li>
+<% end -%>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,5 +1,4 @@
 <%= paginator.render do -%>
-  <%- unless num_pages < 2 -%>
   <nav aria-label="ページネーション">
     <ul class="pagination pagination-modern justify-content-center align-items-center gap-1">
       <%= first_page_tag unless current_page.first? %>
@@ -15,5 +14,4 @@
       <%= last_page_tag unless current_page.last? %>
     </ul>
   </nav>
-  <%- end -%>
 <% end -%>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,19 @@
+<%- unless num_pages < 2 -%>
+<%= paginator.render do -%>
+  <nav aria-label="ページネーション">
+    <ul class="pagination pagination-modern justify-content-center align-items-center gap-1">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end -%>
+<%- end -%>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,5 +1,5 @@
-<%- unless num_pages < 2 -%>
 <%= paginator.render do -%>
+  <%- unless num_pages < 2 -%>
   <nav aria-label="ページネーション">
     <ul class="pagination pagination-modern justify-content-center align-items-center gap-1">
       <%= first_page_tag unless current_page.first? %>
@@ -15,5 +15,5 @@
       <%= last_page_tag unless current_page.last? %>
     </ul>
   </nav>
+  <%- end -%>
 <% end -%>
-<%- end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,5 @@
+<li class="page-item">
+  <%= link_to url, remote: remote, rel: "prev", class: "page-link", aria: { label: "前のページ" } do %>
+    <i class="bi bi-chevron-left"></i>
+  <% end %>
+</li>


### PR DESCRIPTION
## 概要

ゲーム一覧画面で5件しか表示されていなかった問題を修正し、1ページ10件表示に変更。
またページネーションUIが存在しなかったため追加。

## 変更内容

- **`app/controllers/games_controller.rb`** — `per(5)` → `per(10)` に変更（ハード絞り込み時も同様）
- **`app/views/games/index.html.erb`** — `paginate @games` によるページネーションUIを追加

## テスト手順

- [ ] トップページで10件のゲームが表示されることを確認
- [ ] ページネーションのリンクが表示され、次ページへ遷移できることを確認
- [ ] ハードウェアで絞り込んだ場合も10件表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)