### PR TITLE
ヘッダーのハードウェア表示を主要5件+もっと見るドロップダウンに変更

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,11 +9,27 @@
         <li class="nav-item">
           <%= link_to "Top", root_path,class:"nav-link active" %>
         </li>
-        <%Hardware.all.each do |hardware|%>
+        <% primary_names = ["Nintendo Switch 2", "Nintendo Switch", "PlayStation 5", "Xbox Series X|S", "PC (Microsoft Windows)"] %>
+        <% hardwares = Hardware.all.to_a %>
+        <% primary_hardwares = hardwares.select { |h| primary_names.include?(h.name) }.sort_by { |h| primary_names.index(h.name) } %>
+        <% extra_hardwares = hardwares.reject { |h| primary_names.include?(h.name) } %>
+        <%primary_hardwares.each do |hardware|%>
           <li class="nav-item">
             <%= link_to hardware.name,games_path(name: hardware.id),class:"nav-link"%>
           </li>
         <%end%>
+        <% if extra_hardwares.any? %>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              もっと見る
+            </a>
+            <ul class="dropdown-menu">
+              <% extra_hardwares.each do |hardware| %>
+                <li><%= link_to hardware.name, games_path(name: hardware.id), class: "dropdown-item" %></li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
       <ul class="navbar-nav ms-auto">
         <% if current_user %>
           <li class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- Nintendo Switch 2, Nintendo Switch, PlayStation 5, Xbox Series X|S, PC (Microsoft Windows) の5件を常にヘッダーに表示
- それ以外のハードウェアは「もっと見る」ドロップダウンに格納
- ハードウェアが増えてもヘッダーが圧迫されない構成に変更

## Test plan
- [x] ヘッダーに主要5件のハードウェアが表示されることを確認
- [x] 「もっと見る」クリックでドロップダウンが開き、残りのハードウェアが表示されることを確認
- [x] 各リンクをクリックして正しいゲーム一覧ページに遷移することを確認
- [x] モバイル表示（ハンバーガーメニュー）でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)