### PR TITLE
ゲーム詳細からパブリッシャー/ハードウェア/ジャンルで絞り込みリンクを追加

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,14 @@
 class GamesController < ApplicationController
     def index
-        @games = params[:name].present? ? Hardware.find(params[:name]).games.order(release_date: :desc).page(params[:page]).per(10) : Game.order(release_date: :desc).page(params[:page]).per(10)
+        @games = if params[:name].present?
+            Hardware.find(params[:name]).games.order(release_date: :desc).page(params[:page]).per(10)
+        elsif params[:maker].present?
+            Game.where(maker: params[:maker]).order(release_date: :desc).page(params[:page]).per(10)
+        elsif params[:genre_id].present?
+            Genre.find(params[:genre_id]).games.order(release_date: :desc).page(params[:page]).per(10)
+        else
+            Game.order(release_date: :desc).page(params[:page]).per(10)
+        end
         #@hardwares = Hardware.where(id: GameHardware.where(game_id: Game.where(id: @games)))
         #@genres = Genre.where(id: GameGenre.where(game_id: Game.where(id: @games)))
     end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,6 +1,10 @@
 <%content_for :page_title do%>
   <%if params[:name].present?%>
     <%=Hardware.find(params[:name].to_i).name%>
+  <%elsif params[:maker].present?%>
+    <%=params[:maker]%>
+  <%elsif params[:genre_id].present?%>
+    <%=Genre.find(params[:genre_id].to_i).name%>
   <%else%>
     Home
   <%end%>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -16,20 +16,24 @@
       <h2><%= @game.title%></h2>
       <dl class="row">
         <dt class="col-sm-3">パブリッシャー</dt>
-        <dd class="col-sm-9"><%= @game.maker%></dd>
+        <dd class="col-sm-9"><%= link_to @game.maker, games_path(maker: @game.maker), class: "badge rounded-pill bg-secondary text-decoration-none fs-6 fw-normal" %></dd>
         <dt class="col-sm-3">リリース日</dt>
         <dd class="col-sm-9"><%=@game.release_date%></dd>
         <dt class="col-sm-3">ハードウェア</dt>
         <dd class="col-sm-9">
-          <% @hardwares.each do |hardware|%>
-            <p><%=hardware.name%></p>
-          <% end %>
+          <div class="d-flex flex-wrap gap-2">
+            <% @hardwares.each do |hardware|%>
+              <%= link_to hardware.name, games_path(name: hardware.id), class: "badge rounded-pill bg-primary text-decoration-none fs-6 fw-normal" %>
+            <% end %>
+          </div>
         </dd>
         <dt class="col-sm-3">ジャンル</dt>
         <dd class="col-sm-9">
-          <% @genres.each do |genre|%>
-            <p><%=genre.name%></p>
-          <% end %>
+          <div class="d-flex flex-wrap gap-2">
+            <% @genres.each do |genre|%>
+              <%= link_to genre.name, games_path(genre_id: genre.id), class: "badge rounded-pill bg-success text-decoration-none fs-6 fw-normal" %>
+            <% end %>
+          </div>
         </dd>
       </dl>
       <%if !user_signed_in? or !@reviews.exists?(user_id: current_user.id)%>


### PR DESCRIPTION
## Summary
- ゲーム詳細ページのパブリッシャー・ハードウェア・ジャンルをクリックすると、該当の絞り込みが適用されたゲーム一覧に遷移できるようにした
- Bootstrap pill バッジデザインのリンクを採用し、パブリッシャー（グレー）・ハードウェア（青）・ジャンル（緑）で色分け
- `GamesController#index` に `params[:maker]` および `params[:genre_id]` による絞り込みを追加

## Test plan
- [x] ゲーム詳細ページでパブリッシャーをクリック → 同名パブリッシャーのゲーム一覧が表示されること
- [x] ゲーム詳細ページでハードウェアをクリック → 該当ハードウェアのゲーム一覧が表示されること
- [x] ゲーム詳細ページでジャンルをクリック → 該当ジャンルのゲーム一覧が表示されること
- [x] 絞り込み時のページタイトルが正しく表示されること
- [x] 絞り込みなし（ホーム）の動作が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)