### PR TITLE
MetacriticのMedia Scoreをゲーム詳細画面に表示

### DIFF
--- a/app/services/igdb_service.rb
+++ b/app/services/igdb_service.rb
@@ -60,6 +60,7 @@ class IgdbService
   #   genres.name                  → genres.name (正規化)
   #   involved_companies.*         → games.maker (publisher 優先, 次に developer)
   #   cover.image_id               → games.cover (CarrierWave でダウンロード保存)
+  #   aggregated_rating            → games.aggregated_rating (Metacritic等の外部批評家スコア)
   def fetch_games(days_ago: 1)
     since    = (Date.today - days_ago).to_time.to_i
     till_now = Time.now.to_i
@@ -72,7 +73,8 @@ class IgdbService
              involved_companies.company.name,
              involved_companies.developer,
              involved_companies.publisher,
-             cover.image_id;
+             cover.image_id,
+             aggregated_rating;
       where first_release_date >= #{since} & first_release_date <= #{till_now};
       sort first_release_date desc;
       limit 500;
@@ -106,9 +108,10 @@ class IgdbService
   def sync_game(data)
     game = Game.find_or_initialize_by(igdb_id: data['id'])
 
-    game.title        = data['name']
-    game.release_date = Time.at(data['first_release_date']).to_date if data['first_release_date']
-    game.maker        = extract_maker(data['involved_companies'])
+    game.title              = data['name']
+    game.release_date       = Time.at(data['first_release_date']).to_date if data['first_release_date']
+    game.maker              = extract_maker(data['involved_companies'])
+    game.aggregated_rating  = data['aggregated_rating']
 
     game.save!
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -36,6 +36,18 @@
           </div>
         </dd>
       </dl>
+      <% if @game.aggregated_rating.present? %>
+        <div class="d-flex align-items-center gap-3 mt-2 mb-3">
+          <div class="<%= @game.aggregated_rating >= 75 ? 'bg-success' : (@game.aggregated_rating >= 50 ? 'bg-warning' : 'bg-danger') %> text-white rounded d-flex align-items-center justify-content-center fw-bold"
+               style="width:3.5rem;height:3.5rem;font-size:1.5rem;">
+            <%= @game.aggregated_rating.round %>
+          </div>
+          <div>
+            <div class="fw-bold">Metacritic</div>
+            <div class="text-muted small">メディアスコア</div>
+          </div>
+        </div>
+      <% end %>
       <%if !user_signed_in? or !@reviews.exists?(user_id: current_user.id)%>
         <%=link_to 'レビュー投稿', new_game_review_path(@game), class:"btn btn-primary"%>
       <%else%>

--- a/db/migrate/20260310120719_add_aggregated_rating_to_games.rb
+++ b/db/migrate/20260310120719_add_aggregated_rating_to_games.rb
@@ -1,0 +1,5 @@
+class AddAggregatedRatingToGames < ActiveRecord::Migration[7.0]
+  def change
+    add_column :games, :aggregated_rating, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_10_000001) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_10_120719) do
   create_table "game_genres", force: :cascade do |t|
     t.integer "game_id", null: false
     t.integer "genre_id", null: false
@@ -37,6 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_10_000001) do
     t.datetime "updated_at", null: false
     t.integer "igdb_id"
     t.string "cover"
+    t.float "aggregated_rating"
     t.index ["igdb_id"], name: "index_games_on_igdb_id", unique: true
   end
 


### PR DESCRIPTION
## Summary

- `games`テーブルに`aggregated_rating` (float) カラムを追加するマイグレーション
- `IgdbService`の`fetch_games`に`aggregated_rating`フィールドを追加し、IGDB同期時に自動保存
- ゲーム詳細画面にMetacriticスコアをカラーコード付きバッジで表示（75以上:緑、50〜74:黄、50未満:赤）

## Test plan

- [x] `db:migrate`が正常に完了すること
- [x] スコアを持つゲームの詳細画面でMetacriticバッジが表示されること
- [x] スコアなしのゲームでは表示されないこと
- [x] スコア値に応じて色が正しく切り替わること
- [x] 次回IGDB同期後にaggregated_ratingが保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)