### PR TITLE
検索・ソート・フィルタ・注目機能を追加

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,44 +1,76 @@
 class GamesController < ApplicationController
-    def index
-        @games = if params[:name].present?
-            Hardware.find(params[:name]).games.order(release_date: :desc).page(params[:page]).per(10)
-        elsif params[:maker].present?
-            Game.where(maker: params[:maker]).order(release_date: :desc).page(params[:page]).per(10)
-        elsif params[:genre_id].present?
-            Genre.find(params[:genre_id]).games.order(release_date: :desc).page(params[:page]).per(10)
-        else
-            Game.order(release_date: :desc).page(params[:page]).per(10)
-        end
-        #@hardwares = Hardware.where(id: GameHardware.where(game_id: Game.where(id: @games)))
-        #@genres = Genre.where(id: GameGenre.where(game_id: Game.where(id: @games)))
+  def index
+    @games = Game.all
+
+    # タイトル検索
+    if params[:q].present?
+      @games = @games.where("title LIKE ?", "%#{params[:q]}%")
     end
 
-    def show
-        @game = Game.find(params[:id])
-        @hardwares = Hardware.joins(:game_hardwares).where(game_hardwares: {game_id: @game})
-        #@hardware = Hardware.where(game_id: @game)
-        @genres = Genre.joins(:game_genres).where(game_genres: {game_id: @game})
-        @reviews = Review.where(game_id: @game).includes(:user).order(created_at: :desc)
-        @reviews_include_body = Review.where(game_id: @game).where.not(title: '').includes(:user).order(created_at: :desc)
-        @score_color = score_color(@reviews)
-        @reviews_good_graph = Review.where(game_id: @game).where.not(good_point: 0)
-        @reviews_bad_graph = Review.where(game_id: @game).where.not(bad_point: 0)
+    # フィルタ（サブクエリで重複を回避）
+    if params[:name].present?
+      @games = @games.where(id: GameHardware.where(hardware_id: params[:name]).select(:game_id))
     end
 
-    private
-    def game_params
-        params.require(:game).permit(hardware_ids: [])
+    if params[:genre_id].present?
+      @games = @games.where(id: GameGenre.where(genre_id: params[:genre_id]).select(:game_id))
     end
 
-    def score_color(review)
-        if review.count != 0
-            if review.average(:score) >= 8
-                return "bg-success"
-            elsif review.average(:score) >= 4
-                return "bg-warning"
-            else
-                return "bg-danger"
-            end
-        end
+    if params[:maker].present?
+      @games = @games.where(maker: params[:maker])
     end
+
+    # 注目フィルタ
+    if params[:trending] == "1"
+      @games = @games.where("trending_score > 0")
+    end
+
+    # ソート
+    @games = case params[:sort]
+             when "media_score"
+               # メディアスコア(Metacritic)降順。スコアなしは末尾へ
+               @games.order(Arel.sql("CASE WHEN aggregated_rating IS NULL THEN 1 ELSE 0 END, aggregated_rating DESC"))
+             when "user_score"
+               # レビュー平均スコア降順。レビューなしは末尾へ
+               @games.joins(
+                 "LEFT JOIN (SELECT game_id, AVG(score) AS avg_score FROM reviews GROUP BY game_id) " \
+                 "AS avg_reviews ON avg_reviews.game_id = games.id"
+               ).order(Arel.sql("CASE WHEN avg_reviews.avg_score IS NULL THEN 1 ELSE 0 END, avg_reviews.avg_score DESC"))
+             when "trending"
+               @games.order(trending_score: :desc)
+             else
+               @games.order(release_date: :desc)
+             end
+
+    @games = @games.page(params[:page]).per(10)
+  end
+
+  def show
+    @game = Game.find(params[:id])
+    @hardwares = Hardware.joins(:game_hardwares).where(game_hardwares: { game_id: @game })
+    @genres    = Genre.joins(:game_genres).where(game_genres: { game_id: @game })
+    @reviews   = Review.where(game_id: @game).includes(:user).order(created_at: :desc)
+    @reviews_include_body = Review.where(game_id: @game).where.not(title: '').includes(:user).order(created_at: :desc)
+    @score_color        = score_color(@reviews)
+    @reviews_good_graph = Review.where(game_id: @game).where.not(good_point: 0)
+    @reviews_bad_graph  = Review.where(game_id: @game).where.not(bad_point: 0)
+  end
+
+  private
+
+  def game_params
+    params.require(:game).permit(hardware_ids: [])
+  end
+
+  def score_color(review)
+    return unless review.count != 0
+
+    if review.average(:score) >= 8
+      "bg-success"
+    elsif review.average(:score) >= 4
+      "bg-warning"
+    else
+      "bg-danger"
+    end
+  end
 end

--- a/app/services/reddit_trending_service.rb
+++ b/app/services/reddit_trending_service.rb
@@ -1,0 +1,57 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+# Reddit の公開 JSON API からゲームタイトルの直近1週間の投稿数を取得するサービス
+# APIキー不要。User-Agent ヘッダーのみ必要。
+class RedditTrendingService
+  REDDIT_SEARCH_URL = 'https://www.reddit.com/search.json'
+
+  # ゲームタイトルの直近1週間のReddit投稿数を返す（最大300件）
+  def fetch_post_count(game_title)
+    total = 0
+    after = nil
+
+    # 1ページ100件 × 最大3ページまで取得
+    3.times do
+      params = {
+        q:     "\"#{game_title}\"",
+        sort:  'new',
+        t:     'week',
+        limit: 100,
+        type:  'link'
+      }
+      params[:after] = after if after
+
+      uri = URI(REDDIT_SEARCH_URL)
+      uri.query = URI.encode_www_form(params)
+
+      body  = JSON.parse(get_request(uri).body)
+      posts = body.dig('data', 'children') || []
+      total += posts.size
+      after  = body.dig('data', 'after')
+
+      break if after.nil? || posts.empty?
+
+      sleep 1 # Reddit レート制限対策（未認証は60req/min）
+    end
+
+    total
+  rescue => e
+    Rails.logger.warn("[RedditTrendingService] #{game_title}: #{e.message}")
+    0
+  end
+
+  private
+
+  def get_request(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl      = true
+    http.read_timeout = 15
+
+    req = Net::HTTP::Get.new(uri)
+    req['User-Agent'] = 'GameReviewAggregator/1.0'
+    req['Accept']     = 'application/json'
+    http.request(req)
+  end
+end

--- a/app/services/twitch_trending_service.rb
+++ b/app/services/twitch_trending_service.rb
@@ -1,0 +1,83 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+# Twitch Helix API からゲームの視聴者数を取得するサービス
+# IGDB と同じ Twitch Developer の認証情報を使用する
+# 必要な環境変数: IGDB_CLIENT_ID, IGDB_CLIENT_SECRET
+class TwitchTrendingService
+  TWITCH_TOKEN_URL = 'https://id.twitch.tv/oauth2/token'
+  TWITCH_API_BASE  = 'https://api.twitch.tv/helix'
+
+  def initialize
+    @client_id     = ENV.fetch('IGDB_CLIENT_ID')
+    @client_secret = ENV.fetch('IGDB_CLIENT_SECRET')
+    @access_token  = authenticate
+  end
+
+  # ゲームタイトルに対する現在の合計 Twitch 視聴者数を返す
+  def fetch_viewer_count(game_title)
+    twitch_game = find_twitch_game(game_title)
+    return 0 unless twitch_game
+
+    fetch_total_viewers(twitch_game['id'])
+  rescue => e
+    Rails.logger.warn("[TwitchTrendingService] #{game_title}: #{e.message}")
+    0
+  end
+
+  private
+
+  def authenticate
+    uri = URI(TWITCH_TOKEN_URL)
+    uri.query = URI.encode_www_form(
+      client_id:     @client_id,
+      client_secret: @client_secret,
+      grant_type:    'client_credentials'
+    )
+    response = Net::HTTP.post(uri, '')
+    data = JSON.parse(response.body)
+    raise "Twitch OAuth認証失敗: #{data['message']}" if data['access_token'].nil?
+
+    data['access_token']
+  end
+
+  def find_twitch_game(name)
+    uri = URI("#{TWITCH_API_BASE}/games")
+    uri.query = URI.encode_www_form(name: name)
+    body = JSON.parse(get_request(uri).body)
+    body.dig('data', 0)
+  end
+
+  def fetch_total_viewers(game_id)
+    total  = 0
+    cursor = nil
+
+    loop do
+      query = { game_id: game_id, first: 100 }
+      query[:after] = cursor if cursor
+
+      uri = URI("#{TWITCH_API_BASE}/streams")
+      uri.query = URI.encode_www_form(query)
+      body    = JSON.parse(get_request(uri).body)
+      streams = body['data'] || []
+
+      total  += streams.sum { |s| s['viewer_count'].to_i }
+      cursor  = body.dig('pagination', 'cursor')
+      break if cursor.nil? || streams.empty?
+    end
+
+    total
+  end
+
+  def get_request(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl      = true
+    http.read_timeout = 10
+
+    req = Net::HTTP::Get.new(uri)
+    req['Client-ID']     = @client_id
+    req['Authorization'] = "Bearer #{@access_token}"
+    http.request(req)
+  end
+end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -5,13 +5,150 @@
     <%=params[:maker]%>
   <%elsif params[:genre_id].present?%>
     <%=Genre.find(params[:genre_id].to_i).name%>
+  <%elsif params[:q].present?%>
+    「<%=params[:q]%>」の検索結果
   <%else%>
     Home
   <%end%>
 <%end%>
 <body>
 <%= render "shared/header" %>
-<p></p>
+
+<%# ===== 検索・ソート・フィルタ UI ===== %>
+<div class="px-lg-4 px-2 pt-3">
+
+  <%# 検索フォーム %>
+  <%= form_with url: games_path, method: :get, local: true, class: "d-flex gap-2 mb-3" do |f| %>
+    <%# 現在のフィルタ/ソートを維持する隠しフィールド %>
+    <%= hidden_field_tag :name,     params[:name]     if params[:name].present? %>
+    <%= hidden_field_tag :genre_id, params[:genre_id] if params[:genre_id].present? %>
+    <%= hidden_field_tag :maker,    params[:maker]    if params[:maker].present? %>
+    <%= hidden_field_tag :sort,     params[:sort]     if params[:sort].present? %>
+    <%= hidden_field_tag :trending, params[:trending] if params[:trending].present? %>
+
+    <%= f.text_field :q,
+          value: params[:q], placeholder: "ゲームタイトルで検索...",
+          class: "form-control" %>
+    <%= f.submit "検索", class: "btn btn-primary text-nowrap" %>
+    <%if params[:q].present?%>
+      <%= link_to "クリア",
+            games_path(params.permit(:name, :genre_id, :maker, :sort, :trending).to_h),
+            class: "btn btn-outline-secondary text-nowrap" %>
+    <%end%>
+  <%end%>
+
+  <%# ソート + 注目フィルタ %>
+  <div class="d-flex flex-wrap gap-2 mb-3 align-items-center">
+    <span class="text-muted small">並び順:</span>
+
+    <% sort_base = params.permit(:q, :name, :genre_id, :maker, :trending).to_h %>
+    <%= link_to "発売日",
+          games_path(sort_base.merge(sort: nil)),
+          class: "btn btn-sm #{params[:sort].blank? ? 'btn-secondary' : 'btn-outline-secondary'}" %>
+    <%= link_to "メディアスコア",
+          games_path(sort_base.merge(sort: "media_score")),
+          class: "btn btn-sm #{params[:sort] == 'media_score' ? 'btn-secondary' : 'btn-outline-secondary'}" %>
+    <%= link_to "ユーザースコア",
+          games_path(sort_base.merge(sort: "user_score")),
+          class: "btn btn-sm #{params[:sort] == 'user_score' ? 'btn-secondary' : 'btn-outline-secondary'}" %>
+    <%= link_to "注目度",
+          games_path(sort_base.merge(sort: "trending")),
+          class: "btn btn-sm #{params[:sort] == 'trending' ? 'btn-warning' : 'btn-outline-warning'}" %>
+
+    <span class="text-muted small ms-2">|</span>
+
+    <%# ジャンルフィルタ %>
+    <div class="dropdown">
+      <button class="btn btn-sm <%= params[:genre_id].present? ? 'btn-success' : 'btn-outline-success' %> dropdown-toggle"
+              type="button" data-bs-toggle="dropdown">
+        <% if params[:genre_id].present? %>
+          <%= Genre.find(params[:genre_id].to_i).name %>
+        <% else %>
+          ジャンル
+        <% end %>
+      </button>
+      <ul class="dropdown-menu" style="max-height:300px;overflow-y:auto;">
+        <% if params[:genre_id].present? %>
+          <li>
+            <%= link_to "すべてのジャンル",
+                  games_path(params.permit(:q, :name, :maker, :sort, :trending).to_h),
+                  class: "dropdown-item text-muted" %>
+          </li>
+          <li><hr class="dropdown-divider"></li>
+        <% end %>
+        <% Genre.order(:name).each do |genre| %>
+          <li>
+            <%= link_to genre.name,
+                  games_path(params.permit(:q, :name, :maker, :sort, :trending).to_h.merge(genre_id: genre.id)),
+                  class: "dropdown-item #{'active' if params[:genre_id].to_i == genre.id}" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <span class="text-muted small ms-2">|</span>
+
+    <% trending_base = params.permit(:q, :name, :genre_id, :maker, :sort).to_h %>
+    <% if params[:trending] == "1" %>
+      <%= link_to "🔥 注目中",
+            games_path(trending_base.merge(trending: nil)),
+            class: "btn btn-sm btn-warning" %>
+    <% else %>
+      <%= link_to "🔥 注目のみ",
+            games_path(trending_base.merge(trending: "1")),
+            class: "btn btn-sm btn-outline-warning" %>
+    <% end %>
+  </div>
+
+  <%# アクティブフィルタ表示 %>
+  <% has_filter = params[:name].present? || params[:genre_id].present? ||
+                  params[:maker].present? || params[:q].present? || params[:trending] == "1" %>
+  <% if has_filter %>
+    <div class="d-flex flex-wrap gap-2 mb-3 align-items-center">
+      <span class="text-muted small">フィルタ中:</span>
+
+      <% if params[:name].present? %>
+        <%= link_to games_path(params.permit(:q, :genre_id, :maker, :sort, :trending).to_h),
+              class: "badge rounded-pill bg-primary text-decoration-none" do %>
+          <%= Hardware.find(params[:name].to_i).name %> ×
+        <% end %>
+      <% end %>
+
+      <% if params[:genre_id].present? %>
+        <%= link_to games_path(params.permit(:q, :name, :maker, :sort, :trending).to_h),
+              class: "badge rounded-pill bg-success text-decoration-none" do %>
+          <%= Genre.find(params[:genre_id].to_i).name %> ×
+        <% end %>
+      <% end %>
+
+      <% if params[:maker].present? %>
+        <%= link_to games_path(params.permit(:q, :name, :genre_id, :sort, :trending).to_h),
+              class: "badge rounded-pill bg-secondary text-decoration-none" do %>
+          <%= params[:maker] %> ×
+        <% end %>
+      <% end %>
+
+      <% if params[:q].present? %>
+        <%= link_to games_path(params.permit(:name, :genre_id, :maker, :sort, :trending).to_h),
+              class: "badge rounded-pill bg-secondary text-decoration-none" do %>
+          「<%= params[:q] %>」×
+        <% end %>
+      <% end %>
+
+      <% if params[:trending] == "1" %>
+        <%= link_to games_path(params.permit(:q, :name, :genre_id, :maker, :sort).to_h),
+              class: "badge rounded-pill bg-warning text-decoration-none text-dark" do %>
+          🔥 注目 ×
+        <% end %>
+      <% end %>
+
+      <%= link_to "すべてクリア", games_path(sort: params[:sort].presence),
+            class: "badge rounded-pill bg-danger text-decoration-none ms-1" %>
+    </div>
+  <% end %>
+</div>
+
+<%# ===== ゲーム一覧 ===== %>
 <div class="row row-cols-1 row-cols-lg-2 gx-4 gy-1 m-lg-4">
   <% @games.each do |game| %>
     <%review = Review.where(game_id: game)%>
@@ -27,7 +164,15 @@
             <div class="col-md-10 col-lg-9">
               <div class="card-body">
                 <h5 class="card-title"><%=game.title%></h5>
-                <p class="card-text">スコア: <%=review.average(:score)%></p>
+                <p class="card-text">
+                  スコア: <%=review.average(:score)%>
+                  <%if game.aggregated_rating.present?%>
+                    <span class="ms-2 fw-bold small
+                      <%= game.aggregated_rating >= 75 ? 'text-success' : (game.aggregated_rating >= 50 ? 'text-warning' : 'text-danger') %>">
+                      MC:<%=game.aggregated_rating.round%>
+                    </span>
+                  <%end%>
+                </p>
                 <p class="card-text">発売日: <%=game.release_date%></p>
                 <p class="card-text">パブリッシャー: <%=game.maker%></p>
                 <%hardwares.each do |hardware|%>
@@ -38,7 +183,12 @@
                     <p class="card-text">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<%=hardware.name%></p>
                   <%end%>
                 <%end%>
-                </p>
+                <%if params[:sort] == "trending" && game.respond_to?(:twitch_viewer_count) && game.trending_score.to_f > 0%>
+                  <p class="card-text small text-muted">
+                    Twitch: <%=number_with_delimiter(game.twitch_viewer_count.to_i)%>人 /
+                    Reddit: <%=number_with_delimiter(game.reddit_post_count.to_i)%>件
+                  </p>
+                <%end%>
               </div>
             </div>
           </div>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,3 +9,8 @@ set :output, Rails.root.join('log/cron.log').to_s
 every 1.day, at: '2:00 am' do
   rake 'igdb:sync_new_games'
 end
+
+# 6時間ごとにTwitch・Xからトレンドスコアを更新
+every 6.hours do
+  rake 'trending:update'
+end

--- a/db/migrate/20260310130000_add_trending_to_games.rb
+++ b/db/migrate/20260310130000_add_trending_to_games.rb
@@ -1,0 +1,8 @@
+class AddTrendingToGames < ActiveRecord::Migration[7.0]
+  def change
+    add_column :games, :twitch_viewer_count, :integer, default: 0
+    add_column :games, :reddit_post_count,   :integer, default: 0
+    add_column :games, :trending_score,      :float,   default: 0.0
+    add_column :games, :trending_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_10_120719) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_10_130000) do
   create_table "game_genres", force: :cascade do |t|
     t.integer "game_id", null: false
     t.integer "genre_id", null: false
@@ -38,6 +38,10 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_10_120719) do
     t.integer "igdb_id"
     t.string "cover"
     t.float "aggregated_rating"
+    t.integer "twitch_viewer_count", default: 0
+    t.integer "reddit_post_count", default: 0
+    t.float "trending_score", default: 0.0
+    t.datetime "trending_updated_at"
     t.index ["igdb_id"], name: "index_games_on_igdb_id", unique: true
   end
 

--- a/lib/tasks/trending.rake
+++ b/lib/tasks/trending.rake
@@ -1,0 +1,31 @@
+namespace :trending do
+  desc "Twitch視聴者数・Reddit投稿数を取得してゲームのトレンドスコアを更新する"
+  task update: :environment do
+    twitch = TwitchTrendingService.new
+    reddit = RedditTrendingService.new
+    updated = 0
+    failed  = 0
+
+    Game.find_each do |game|
+      twitch_count = twitch.fetch_viewer_count(game.title)
+      reddit_count = reddit.fetch_post_count(game.title)
+
+      # Twitch視聴者数とReddit投稿数を合算してスコア化
+      # Reddit投稿数に重みを付けて均衡させる
+      score = twitch_count + reddit_count * 100
+
+      game.update!(
+        twitch_viewer_count: twitch_count,
+        reddit_post_count:   reddit_count,
+        trending_score:      score,
+        trending_updated_at: Time.current
+      )
+      updated += 1
+    rescue => e
+      Rails.logger.error("[trending:update] #{game.title}: #{e.message}")
+      failed += 1
+    end
+
+    puts "完了 — 更新: #{updated}, 失敗: #{failed}"
+  end
+end


### PR DESCRIPTION
## Summary

- タイトル検索（部分一致）をゲーム一覧ページに追加
- ソート機能を追加（発売日 / メディアスコア / ユーザースコア / 注目度）
- フィルタ機能を拡張（ジャンル・機種・メーカー・注目を組み合わせ可能）
- Twitch視聴者数 + Reddit投稿数による「注目度」機能を追加

## 変更内容

### 新機能
- **検索**: ゲームタイトルの部分一致検索
- **ソート**: 発売日 / Metacriticスコア / ユーザーレビュー平均 / 注目度
- **ジャンルフィルタ**: 一覧ページ内のドロップダウンから選択可能に
- **注目フィルタ**: 🔥ボタンで注目ゲームのみ絞り込み

### トレンド機能
- `TwitchTrendingService`: Twitch Helix APIでゲームの視聴者数を取得（IGDB認証情報を流用）
- `RedditTrendingService`: Reddit公開JSONAPIで1週間の投稿数を取得（APIキー不要）
- `trending:update` Rakeタスクで全ゲームのスコアを一括更新
- cronで6時間ごとに自動実行（`config/schedule.rb`）

### DB変更
- `games`テーブルに `twitch_viewer_count`, `reddit_post_count`, `trending_score`, `trending_updated_at` を追加

## Test plan

- [x] `bin/rails db:migrate` を実行してマイグレーションを適用
- [x] タイトル検索が部分一致で動作することを確認
- [x] 各ソート（発売日・メディアスコア・ユーザースコア・注目度）が正しく並び替わることを確認
- [x] ジャンルドロップダウンでフィルタが機能することを確認
- [x] 検索・ソート・フィルタを組み合わせても正しく動作することを確認
- [x] `bin/rails trending:update` が正常に完了することを確認（要: `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)