### PR TITLE
検索をアクセント記号・大文字小文字を無視した曖昧検索に対応

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -2,9 +2,10 @@ class GamesController < ApplicationController
   def index
     @games = Game.all
 
-    # タイトル検索
+    # タイトル検索（アクセント記号・大文字小文字を無視した曖昧検索）
     if params[:q].present?
-      @games = @games.where("title LIKE ?", "%#{params[:q]}%")
+      normalized_q = Game.normalize_for_search(params[:q])
+      @games = @games.where("normalized_title LIKE ?", "%#{normalized_q}%")
     end
 
     # フィルタ（サブクエリで重複を回避）

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,4 +6,18 @@ class Game < ApplicationRecord
   has_many :reviews, dependent: :destroy
 
   mount_uploader :cover, CoverUploader
+
+  before_save :set_normalized_title
+
+  # 検索用: アクセント記号・大文字小文字を除去して正規化
+  # 例) "Pokémon" → "pokemon", "FINAL FANTASY" → "final fantasy"
+  def self.normalize_for_search(str)
+    str.unicode_normalize(:nfkd).gsub(/\p{Mn}/, '').downcase
+  end
+
+  private
+
+  def set_normalized_title
+    self.normalized_title = self.class.normalize_for_search(title.to_s)
+  end
 end

--- a/db/migrate/20260311000000_add_normalized_title_to_games.rb
+++ b/db/migrate/20260311000000_add_normalized_title_to_games.rb
@@ -1,0 +1,15 @@
+class AddNormalizedTitleToGames < ActiveRecord::Migration[7.0]
+  def up
+    add_column :games, :normalized_title, :string
+    add_index  :games, :normalized_title
+
+    # 既存ゲームのバックフィル
+    Game.find_each do |game|
+      game.update_column(:normalized_title, Game.normalize_for_search(game.title.to_s))
+    end
+  end
+
+  def down
+    remove_column :games, :normalized_title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_10_130000) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_11_000000) do
   create_table "game_genres", force: :cascade do |t|
     t.integer "game_id", null: false
     t.integer "genre_id", null: false
@@ -42,7 +42,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_10_130000) do
     t.integer "reddit_post_count", default: 0
     t.float "trending_score", default: 0.0
     t.datetime "trending_updated_at"
+    t.string "normalized_title"
     t.index ["igdb_id"], name: "index_games_on_igdb_id", unique: true
+    t.index ["normalized_title"], name: "index_games_on_normalized_title"
   end
 
   create_table "genres", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- `pokemon` で `Pokémon` がヒットするよう、検索の正規化対応を追加

## 変更内容

- `games` テーブルに `normalized_title` カラムを追加
  - アクセント記号除去 + 小文字化したタイトルを保存
  - `before_save` で自動セット
  - マイグレーション実行時に既存ゲームをバックフィル
- `Game.normalize_for_search` メソッドを追加（モデル・コントローラー共有）
- 検索クエリも同様に正規化して `normalized_title LIKE ?` で比較

## 正規化の仕組み

`unicode_normalize(:nfkd)` で合成記号を分離 → `\p{Mn}` で除去 → `downcase`

| 検索ワード | ヒット例 |
|---|---|
| `pokemon` | Pokémon, Pokémon Scarlet |
| `okami` | Ōkami |
| `final fantasy` | FINAL FANTASY VII |

## Test plan

- [x] `bin/rails db:migrate` を実行
- [x] `pokemon` で検索して Pokémon タイトルがヒットすることを確認
- [x] 通常の日本語タイトルの検索が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)